### PR TITLE
Added 'Maliwan Barrels Are Special'

### DIFF
--- a/Borderlands 2 mods/Xarathos517/Maliwan Barrels Are Special.txt
+++ b/Borderlands 2 mods/Xarathos517/Maliwan Barrels Are Special.txt
@@ -1,0 +1,34 @@
+#<Maliwan Barrels Are Special>
+
+#<Description>
+
+    By Xarathos517
+
+    Features;
+
+    Basically an experiment. Sets the various Maliwan barrels (pistol, sniper, launcher) to override the weapons default firing mode with the one from their respective maliwan weapons, hopefully granting splash damage. SMGs don't have a firing mode of their own, so as an option you can override maliwan barreled smgs with the Hellfire firing mode.
+
+#</Description>
+
+#<Code>
+
+    #<Pistols>
+
+    set GD_Weap_Pistol.Barrel.Pistol_Barrel_Maliwan CustomFiringModeDefinition FiringModeDefinition'GD_Weap_Pistol.FiringModes.Bullet_Pistol_Maliwan'
+
+    #</Pistols>
+    #<Snipers>
+    set GD_Weap_SniperRifles.Barrel.SR_Barrel_Maliwan CustomFiringModeDefinition FiringModeDefinition'GD_Weap_SniperRifles.FiringModes.Bullet_Sniper_Maliwan'
+    #</Snipers>
+    #<SMG Barrel uses Hellfire Definition>
+
+        set GD_Weap_SMG.Barrel.SMG_Barrel_Maliwan CustomFiringModeDefinition FiringModeDefinition'GD_Weap_SMG.FiringModes.Bullet_SMG_HellFire'
+
+    #</SMG Barrel uses Hellfire Definition>
+    #<Launchers>
+    set GD_Weap_Launchers.Barrel.L_Barrel_Maliwan CustomFiringModeDefinition FiringModeDefinition'GD_Weap_Launchers.FiringModes.FM_Rocket_Maliwan'
+    #</Launchers>
+
+#</Code>
+
+#</Maliwan Barrels Are Special>


### PR DESCRIPTION
Basically an experiment. Sets the various Maliwan barrels (pistol, sniper, launcher) to override the weapons default firing mode with the one from their respective weapons, hopefully granting splash damage. SMGs don't have a firing mode of their own, so as an option you can override Maliwan barreled smgs with the Hellfire firing mode.