### PR TITLE
Ghost Rider (version 1.1.0)

### DIFF
--- a/Borderlands 2 mods/WarMocK/Ghostrider/Ghostrider.txt
+++ b/Borderlands 2 mods/WarMocK/Ghostrider/Ghostrider.txt
@@ -4,9 +4,9 @@
 
         Mod author: WarMocK
 	
-	Release Date: 06-19-2018
+	Release Date: 06-30-2018
 	
-	Version: 1.0.0
+	Version: 1.1.0
 	
 	Summary: 
 		
@@ -41,6 +41,8 @@
 	Gibbed codes (OP 8):
 		
 	- Modified Law with gunstock on accessory slot 2: BL2(hwAAAABjYQCHRwJABgGFQsOIhRENAwLG/////9IwNmBMw3CCgQ3j)
+	
+	- Best version of the Ghost Rider: BL2(BwAAAADzQAkUEV6gYxBQqAFEBAQIxFXE/////////79VxP8/WsQ=)
 
         Acknowledgements:
 		
@@ -150,19 +152,19 @@
 
         #<Only body parts with positive effects on Special01 and Special02>
 
-		set GD_Shields.Body.PartsList_Body_Booster_Legendary WeightedParts ((bDisabled=False,Part=ShieldPartDefinition'GD_Shields.Body.Body1_Tediore',Manufacturers=((Manufacturer=None,DefaultWeightIndex=3)),MinGameStageIndex=0,MaxGameStageIndex=1,DefaultWeightIndex=2),(bDisabled=False,Part=ShieldPartDefinition'GD_Shields.Body.Body2_Bandit',Manufacturers=((Manufacturer=None,DefaultWeightIndex=3)),MinGameStageIndex=1,MaxGameStageIndex=1,DefaultWeightIndex=2),(bDisabled=False,Part=ShieldPartDefinition'GD_Shields.Body.Body3_Vladof',Manufacturers=((Manufacturer=None,DefaultWeightIndex=3)),MinGameStageIndex=1,MaxGameStageIndex=1,DefaultWeightIndex=2),(bDisabled=False,Part=ShieldPartDefinition'GD_Shields.Body.Body5_Anshin',Manufacturers=((Manufacturer=None,DefaultWeightIndex=3)),MinGameStageIndex=1,MaxGameStageIndex=1,DefaultWeightIndex=0),(bDisabled=False,Part=ShieldPartDefinition'GD_Shields.Body.Body5_Maliwan',Manufacturers=((Manufacturer=None,DefaultWeightIndex=3)),MinGameStageIndex=0,MaxGameStageIndex=1,DefaultWeightIndex=4),(bDisabled=False,Part=ShieldPartDefinition'GD_Shields.Body.Body7_Hyperion',Manufacturers=((Manufacturer=None,DefaultWeightIndex=3)),MinGameStageIndex=0,MaxGameStageIndex=1,DefaultWeightIndex=2),(bDisabled=False,Part=ShieldPartDefinition'GD_Shields.Body.Body8_Pangolin',Manufacturers=((Manufacturer=None,DefaultWeightIndex=3)),MinGameStageIndex=1,MaxGameStageIndex=1,DefaultWeightIndex=2))
+		set GD_Shields.Body.PartsList_Body_Booster_Legendary WeightedParts ((bDisabled=False,Part=ShieldPartDefinition'GD_Shields.Body.Body1_Tediore',Manufacturers=((Manufacturer=None,DefaultWeightIndex=3)),MinGameStageIndex=0,MaxGameStageIndex=1,DefaultWeightIndex=2),(bDisabled=False,Part=ShieldPartDefinition'GD_Shields.Body.Body5_Maliwan',Manufacturers=((Manufacturer=None,DefaultWeightIndex=3)),MinGameStageIndex=0,MaxGameStageIndex=1,DefaultWeightIndex=4),(bDisabled=False,Part=ShieldPartDefinition'GD_Shields.Body.Body7_Hyperion',Manufacturers=((Manufacturer=None,DefaultWeightIndex=3)),MinGameStageIndex=0,MaxGameStageIndex=1,DefaultWeightIndex=2))
 
         #</Only body parts with positive effects on Special01 and Special02>
 
         #<Vladof and Anshin battery only>
 
-		set GD_Shields.Battery.PartsList_Battery_Booster_Legendary WeightedParts ((bDisabled=False,Part=ShieldPartDefinition'GD_Shields.Battery.Battery1_Tediore',Manufacturers=((Manufacturer=None,DefaultWeightIndex=3)),MinGameStageIndex=1,MaxGameStageIndex=1,DefaultWeightIndex=2),(bDisabled=False,Part=ShieldPartDefinition'GD_Shields.Battery.Battery3_Vladof',Manufacturers=((Manufacturer=None,DefaultWeightIndex=3)),MinGameStageIndex=0,MaxGameStageIndex=1,DefaultWeightIndex=2),(bDisabled=False,Part=ShieldPartDefinition'GD_Shields.Battery.Battery4_Dahl',Manufacturers=((Manufacturer=None,DefaultWeightIndex=3)),MinGameStageIndex=1,MaxGameStageIndex=1,DefaultWeightIndex=2),(bDisabled=False,Part=ShieldPartDefinition'GD_Shields.Battery.Battery5_Anshin',Manufacturers=,MinGameStageIndex=0,MaxGameStageIndex=1,DefaultWeightIndex=1),(bDisabled=False,Part=ShieldPartDefinition'GD_Shields.Battery.Battery5_Maliwan',Manufacturers=((Manufacturer=None,DefaultWeightIndex=3)),MinGameStageIndex=1,MaxGameStageIndex=1,DefaultWeightIndex=4),(bDisabled=False,Part=ShieldPartDefinition'GD_Shields.Battery.Battery7_Hyperion',Manufacturers=((Manufacturer=None,DefaultWeightIndex=3)),MinGameStageIndex=1,MaxGameStageIndex=1,DefaultWeightIndex=2),(bDisabled=False,Part=ShieldPartDefinition'GD_Shields.Battery.Battery8_Pangolin',Manufacturers=((Manufacturer=None,DefaultWeightIndex=3)),MinGameStageIndex=1,MaxGameStageIndex=1,DefaultWeightIndex=2))
+		set GD_Shields.Battery.PartsList_Battery_Booster_Legendary WeightedParts ((bDisabled=False,Part=ShieldPartDefinition'GD_Shields.Battery.Battery1_Tediore',Manufacturers=((Manufacturer=None,DefaultWeightIndex=3)),MinGameStageIndex=1,MaxGameStageIndex=1,DefaultWeightIndex=2),(bDisabled=False,Part=ShieldPartDefinition'GD_Shields.Battery.Battery3_Vladof',Manufacturers=((Manufacturer=None,DefaultWeightIndex=3)),MinGameStageIndex=0,MaxGameStageIndex=1,DefaultWeightIndex=2),(bDisabled=False,Part=ShieldPartDefinition'GD_Shields.Battery.Battery5_Anshin',Manufacturers=,MinGameStageIndex=0,MaxGameStageIndex=1,DefaultWeightIndex=1))
 
         #</Vladof and Anshin battery only>
 
         #<Pangolin Capacitors Only>
 
-		set GD_Shields.Capacitor.PartsList_Capacitor_Booster_Legendary WeightedParts ((bDisabled=False,Part=ShieldPartDefinition'GD_Shields.Capacitor.Capacitor1_Tediore',Manufacturers=((Manufacturer=None,DefaultWeightIndex=3)),MinGameStageIndex=1,MaxGameStageIndex=1,DefaultWeightIndex=2),(bDisabled=False,Part=ShieldPartDefinition'GD_Shields.Capacitor.Capacitor3_Vladof',Manufacturers=((Manufacturer=None,DefaultWeightIndex=3)),MinGameStageIndex=1,MaxGameStageIndex=1,DefaultWeightIndex=4),(bDisabled=False,Part=ShieldPartDefinition'GD_Shields.Capacitor.Capacitor5_Anshin',Manufacturers=,MinGameStageIndex=1,MaxGameStageIndex=1,DefaultWeightIndex=5),(bDisabled=False,Part=ShieldPartDefinition'GD_Shields.Capacitor.Capacitor5_Maliwan_CorrosiveRes',Manufacturers=((Manufacturer=None,DefaultWeightIndex=3)),MinGameStageIndex=1,MaxGameStageIndex=1,DefaultWeightIndex=5),(bDisabled=False,Part=ShieldPartDefinition'GD_Shields.Capacitor.Capacitor5_Maliwan_FireRes',Manufacturers=((Manufacturer=None,DefaultWeightIndex=3)),MinGameStageIndex=1,MaxGameStageIndex=1,DefaultWeightIndex=5),(bDisabled=False,Part=ShieldPartDefinition'GD_Shields.Capacitor.Capacitor5_Maliwan_ShockRes',Manufacturers=((Manufacturer=None,DefaultWeightIndex=3)),MinGameStageIndex=1,MaxGameStageIndex=1,DefaultWeightIndex=5),(bDisabled=False,Part=ShieldPartDefinition'GD_Shields.Capacitor.Capacitor6_Torgue_ExplosiveRes',Manufacturers=((Manufacturer=None,DefaultWeightIndex=3)),MinGameStageIndex=1,MaxGameStageIndex=1,DefaultWeightIndex=5),(bDisabled=False,Part=ShieldPartDefinition'GD_Shields.Capacitor.Capacitor7_Hyperion',Manufacturers=((Manufacturer=None,DefaultWeightIndex=3)),MinGameStageIndex=1,MaxGameStageIndex=1,DefaultWeightIndex=4),(bDisabled=False,Part=ShieldPartDefinition'GD_Shields.Capacitor.Capacitor8_Pangolin',Manufacturers=((Manufacturer=None,DefaultWeightIndex=3)),MinGameStageIndex=0,MaxGameStageIndex=1,DefaultWeightIndex=0))
+		set GD_Shields.Capacitor.PartsList_Capacitor_Booster_Legendary WeightedParts ((bDisabled=False,Part=ShieldPartDefinition'GD_Shields.Capacitor.Capacitor8_Pangolin',Manufacturers=((Manufacturer=None,DefaultWeightIndex=3)),MinGameStageIndex=0,MaxGameStageIndex=1,DefaultWeightIndex=0))
 
         #</Pangolin Capacitors Only>
 


### PR DESCRIPTION
Changed the balanced items to make sure that only certain shield parts will spawn to prevent the shield from being too OP or outright broken because some part combinations result in negative bonus health and roid damage.