### PR TITLE
View offset changer

### DIFF
--- a/Pre Sequel Mods/iNSANE's mod
+++ b/Pre Sequel Mods/iNSANE's mod
@@ -1,0 +1,118 @@
+<BLCMM v="1">
+#<!!!You opened a file saved with BLCMM in FilterTool. Please update to BLCMM to properly open this file!!!>
+	<head>
+		<type name="TPS" offline="false"/>
+		<profiles>
+			<profile name="default" current="true"/>
+		</profiles>
+	</head>
+	<body>
+		<category name="patch">
+			<comment>By iNSANE</comment>
+			<comment>This patch changes the position of the weapons in the game to not be right in your face.</comment>
+			<category name="Weapon View Offset Code">
+				<category name="Assault Rifles">
+					<code profiles="default">set GD_Weap_AssaultRifle.A_Weapons.WT_Dahl_AssaultRifle PlayerViewOffset (X=25.500000,Y=2.000000,Z=2.000000)</code>
+					<code profiles="default">set GD_Weap_AssaultRifle.A_Weapons.WT_Bandit_AssaultRifle PlayerViewOffset (X=20.000000,Y=0.000000,Z=2.000000)</code>
+					<code profiles="default">set GD_Weap_AssaultRifle.A_Weapons.WT_Torgue_AssaultRifle PlayerViewOffset (X=30.000000,Y=4.000000,Z=2.000000)</code>
+					<code profiles="default">set GD_Weap_AssaultRifle.A_Weapons.WT_Jakobs_AssaultRifle PlayerViewOffset (X=30.000000,Y=4.000000,Z=2.000000)</code>
+					<code profiles="default">set GD_Weap_AssaultRifle.A_Weapons.WT_Vladof_AssaultRifle PlayerViewOffset (X=39.200000,Y=4.000000,Z=0.200000)</code>
+				</category>
+				<category name="Launchers">
+					<code profiles="default">set GD_Weap_Launchers.A_Weapons.WT_Torgue_Launcher PlayerViewOffset (X=36.000000,Y=-4.000000,Z=0.000000)</code>
+					<code profiles="default">set GD_Weap_Launchers.A_Weapons.WT_Bandit_Launcher PlayerViewOffset (X=36.000000,Y=-4.000000,Z=0.000000)</code>
+					<code profiles="default">set GD_Weap_Launchers.A_Weapons.WT_Maliwan_Launcher PlayerViewOffset (X=36.000000,Y=8.000000,Z=0.000000)</code>
+					<code profiles="default">set GD_Weap_Launchers.A_Weapons.WT_Tediore_Launcher PlayerViewOffset (X=46.000000,Y=-6.000000,Z=-2.000000)</code>
+					<code profiles="default">set GD_Weap_Launchers.A_Weapons.WT_Vladof_Launcher PlayerViewOffset (X=52.000000,Y=1.000000,Z=-1.250000)</code>
+				</category>
+				<category name="Pistols">
+					<code profiles="default">set GD_Weap_Pistol.A_Weapons.WeaponType_Torgue_Pistol PlayerViewOffset (X=46.000000,Y=8.000000,Z=1.000000)</code>
+					<code profiles="default">set GD_Weap_Pistol.A_Weapons.WeaponType_Vladof_Pistol PlayerViewOffset (X=50.000000,Y=8.000000,Z=-1.700000)</code>
+					<code profiles="default">set GD_Weap_Pistol.A_Weapons.WeaponType_Bandit_Pistol PlayerViewOffset (X=46.000000,Y=8.000000,Z=1.000000)</code>
+					<code profiles="default">set GD_Weap_Pistol.A_Weapons.WeaponType_Hyperion_Pistol PlayerViewOffset (X=50.000000,Y=8.000000,Z=-1.000000)</code>
+					<code profiles="default">set GD_Weap_Pistol.A_Weapons.WeaponType_Jakobs_Pistol PlayerViewOffset (X=42.000000,Y=6.000000,Z=0.000000)</code>
+					<code profiles="default">set GD_Weap_Pistol.A_Weapons.WeaponType_Dahl_Pistol PlayerViewOffset (X=46.000000,Y=8.000000,Z=0.000000)</code>
+					<code profiles="default">set GD_Weap_Pistol.A_Weapons.WeaponType_Maliwan_Pistol PlayerViewOffset (X=50.000000,Y=8.000000,Z=0.000000)</code>
+					<code profiles="default">set GD_Weap_Pistol.A_Weapons.WeaponType_Tediore_Pistol PlayerViewOffset (X=42.000000,Y=2.000000,Z=1.000000)</code>
+				</category>
+				<category name="SMGs">
+					<code profiles="default">set GD_Weap_SMG.A_Weapons.WT_SMG_Bandit PlayerViewOffset (X=25.000000,Y=8.000000,Z=-1.000000)</code>
+					<code profiles="default">set GD_Weap_SMG.A_Weapons.WT_SMG_Dahl PlayerViewOffset (X=30.000000,Y=8.000000,Z=-1.700000)</code>
+					<code profiles="default">set GD_Weap_SMG.A_Weapons.WT_SMG_Hyperion PlayerViewOffset (X=38.000000,Y=8.000000,Z=-1.700000)</code>
+					<code profiles="default">set GD_Weap_SMG.A_Weapons.WT_SMG_Maliwan PlayerViewOffset (X=30.000000,Y=8.000000,Z=-1.700000)</code>
+					<code profiles="default">set GD_Weap_SMG.A_Weapons.WT_SMG_Tediore PlayerViewOffset (X=30.000000,Y=8.000000,Z=-1.700000)</code>
+				</category>
+				<category name="Shotguns">
+					<code profiles="default">set GD_Weap_Shotgun.A_Weapons.WT_Tediore_Shotgun PlayerViewOffset (X=32.500000,Y=0.000000,Z=-0.700000)</code>
+					<code profiles="default">set GD_Weap_Shotgun.A_Weapons.WT_Hyperion_Shotgun PlayerViewOffset (X=38.500000,Y=4.000000,Z=-1.000000)</code>
+					<code profiles="default">set GD_Weap_Shotgun.A_Weapons.WT_Bandit_Shotgun PlayerViewOffset (X=30.500000,Y=4.000000,Z=1.000000)</code>
+					<category name="Jakobs">
+						<code profiles="default">set GD_Weap_Shotgun.A_Weapons.WT_Jakobs_Shotgun FirstPersonMeshFOV 51</code>
+						<code profiles="default">set GD_Weap_Shotgun.A_Weapons.WT_Jakobs_Shotgun PlayerViewOffset (X=32.500000,Y=4.000000,Z=-1.000000)</code>
+					</category>
+					<category name="Torgue">
+						<code profiles="default">set GD_Weap_Shotgun.A_Weapons.WT_Torgue_Shotgun FirstPersonMeshFOV 45</code>
+						<code profiles="default">set GD_Weap_Shotgun.A_Weapons.WT_Torgue_Shotgun PlayerViewOffset (X=38.500000,Y=0.000000,Z=-1.000000)</code>
+					</category>
+				</category>
+				<category name="Sniper Rifles">
+					<code profiles="default">set GD_Weap_SniperRifles.A_Weapons.WeaponType_Dahl_Sniper PlayerViewOffset (X=46.000000,Y=8.000000,Z=0.000000)</code>
+					<code profiles="default">set GD_Weap_SniperRifles.A_Weapons.WeaponType_Hyperion_Sniper PlayerViewOffset (X=36.000000,Y=8.000000,Z=0.000000)</code>
+					<code profiles="default">set GD_Weap_SniperRifles.A_Weapons.WeaponType_Jakobs_Sniper PlayerViewOffset (X=39.000000,Y=0.000000,Z=0.000000)</code>
+					<code profiles="default">set GD_Weap_SniperRifles.A_Weapons.WeaponType_Maliwan_Sniper PlayerViewOffset (X=36.000000,Y=6.000000,Z=0.000000)</code>
+					<code profiles="default">set GD_Weap_SniperRifles.A_Weapons.WeaponType_Vladof_Sniper PlayerViewOffset (X=40.000000,Y=3.000000,Z=-2.000000)</code>
+				</category>
+				<category name="Laser Rifles">
+					<code profiles="default">set GD_Cork_Weap_Lasers.A_Weapons.WT_Dahl_Laser PlayerViewOffset (X=56.500000,Y=12.000000,Z=-6.000000)</code>
+					<code profiles="default">set GD_Cork_Weap_Lasers.A_Weapons.WT_Hyperion_Laser PlayerViewOffset (X=56.500000,Y=12.000000,Z=-6.000000)</code>
+					<code profiles="default">set GD_Cork_Weap_Lasers.A_Weapons.WT_Bandit_Laser PlayerViewOffset (X=56.500000,Y=12.000000,Z=-6.000000)</code>
+					<code profiles="default">set GD_Cork_Weap_Lasers.A_Weapons.WT_Maliwan_Laser PlayerViewOffset (X=56.500000,Y=12.000000,Z=-6.000000)</code>
+					<code profiles="default">set GD_Cork_Weap_Lasers.A_Weapons.WT_Tediore_Laser PlayerViewOffset (X=56.500000,Y=12.000000,Z=-6.000000)</code>
+				</category>
+			</category>
+		</category>
+	</body>
+</BLCMM>
+
+#Commands:
+set GD_Weap_AssaultRifle.A_Weapons.WT_Dahl_AssaultRifle PlayerViewOffset (X=25.500000,Y=2.000000,Z=2.000000)
+set GD_Weap_AssaultRifle.A_Weapons.WT_Bandit_AssaultRifle PlayerViewOffset (X=20.000000,Y=0.000000,Z=2.000000)
+set GD_Weap_AssaultRifle.A_Weapons.WT_Torgue_AssaultRifle PlayerViewOffset (X=30.000000,Y=4.000000,Z=2.000000)
+set GD_Weap_AssaultRifle.A_Weapons.WT_Jakobs_AssaultRifle PlayerViewOffset (X=30.000000,Y=4.000000,Z=2.000000)
+set GD_Weap_AssaultRifle.A_Weapons.WT_Vladof_AssaultRifle PlayerViewOffset (X=39.200000,Y=4.000000,Z=0.200000)
+set GD_Weap_Launchers.A_Weapons.WT_Torgue_Launcher PlayerViewOffset (X=36.000000,Y=-4.000000,Z=0.000000)
+set GD_Weap_Launchers.A_Weapons.WT_Bandit_Launcher PlayerViewOffset (X=36.000000,Y=-4.000000,Z=0.000000)
+set GD_Weap_Launchers.A_Weapons.WT_Maliwan_Launcher PlayerViewOffset (X=36.000000,Y=8.000000,Z=0.000000)
+set GD_Weap_Launchers.A_Weapons.WT_Tediore_Launcher PlayerViewOffset (X=46.000000,Y=-6.000000,Z=-2.000000)
+set GD_Weap_Launchers.A_Weapons.WT_Vladof_Launcher PlayerViewOffset (X=52.000000,Y=1.000000,Z=-1.250000)
+set GD_Weap_Pistol.A_Weapons.WeaponType_Torgue_Pistol PlayerViewOffset (X=46.000000,Y=8.000000,Z=1.000000)
+set GD_Weap_Pistol.A_Weapons.WeaponType_Vladof_Pistol PlayerViewOffset (X=50.000000,Y=8.000000,Z=-1.700000)
+set GD_Weap_Pistol.A_Weapons.WeaponType_Bandit_Pistol PlayerViewOffset (X=46.000000,Y=8.000000,Z=1.000000)
+set GD_Weap_Pistol.A_Weapons.WeaponType_Hyperion_Pistol PlayerViewOffset (X=50.000000,Y=8.000000,Z=-1.000000)
+set GD_Weap_Pistol.A_Weapons.WeaponType_Jakobs_Pistol PlayerViewOffset (X=42.000000,Y=6.000000,Z=0.000000)
+set GD_Weap_Pistol.A_Weapons.WeaponType_Dahl_Pistol PlayerViewOffset (X=46.000000,Y=8.000000,Z=0.000000)
+set GD_Weap_Pistol.A_Weapons.WeaponType_Maliwan_Pistol PlayerViewOffset (X=50.000000,Y=8.000000,Z=0.000000)
+set GD_Weap_Pistol.A_Weapons.WeaponType_Tediore_Pistol PlayerViewOffset (X=42.000000,Y=2.000000,Z=1.000000)
+set GD_Weap_SMG.A_Weapons.WT_SMG_Bandit PlayerViewOffset (X=25.000000,Y=8.000000,Z=-1.000000)
+set GD_Weap_SMG.A_Weapons.WT_SMG_Dahl PlayerViewOffset (X=30.000000,Y=8.000000,Z=-1.700000)
+set GD_Weap_SMG.A_Weapons.WT_SMG_Hyperion PlayerViewOffset (X=38.000000,Y=8.000000,Z=-1.700000)
+set GD_Weap_SMG.A_Weapons.WT_SMG_Maliwan PlayerViewOffset (X=30.000000,Y=8.000000,Z=-1.700000)
+set GD_Weap_SMG.A_Weapons.WT_SMG_Tediore PlayerViewOffset (X=30.000000,Y=8.000000,Z=-1.700000)
+set GD_Weap_Shotgun.A_Weapons.WT_Tediore_Shotgun PlayerViewOffset (X=32.500000,Y=0.000000,Z=-0.700000)
+set GD_Weap_Shotgun.A_Weapons.WT_Hyperion_Shotgun PlayerViewOffset (X=38.500000,Y=4.000000,Z=-1.000000)
+set GD_Weap_Shotgun.A_Weapons.WT_Bandit_Shotgun PlayerViewOffset (X=30.500000,Y=4.000000,Z=1.000000)
+set GD_Weap_Shotgun.A_Weapons.WT_Jakobs_Shotgun FirstPersonMeshFOV 51
+set GD_Weap_Shotgun.A_Weapons.WT_Jakobs_Shotgun PlayerViewOffset (X=32.500000,Y=4.000000,Z=-1.000000)
+set GD_Weap_Shotgun.A_Weapons.WT_Torgue_Shotgun FirstPersonMeshFOV 45
+set GD_Weap_Shotgun.A_Weapons.WT_Torgue_Shotgun PlayerViewOffset (X=38.500000,Y=0.000000,Z=-1.000000)
+set GD_Weap_SniperRifles.A_Weapons.WeaponType_Dahl_Sniper PlayerViewOffset (X=46.000000,Y=8.000000,Z=0.000000)
+set GD_Weap_SniperRifles.A_Weapons.WeaponType_Hyperion_Sniper PlayerViewOffset (X=36.000000,Y=8.000000,Z=0.000000)
+set GD_Weap_SniperRifles.A_Weapons.WeaponType_Jakobs_Sniper PlayerViewOffset (X=39.000000,Y=0.000000,Z=0.000000)
+set GD_Weap_SniperRifles.A_Weapons.WeaponType_Maliwan_Sniper PlayerViewOffset (X=36.000000,Y=6.000000,Z=0.000000)
+set GD_Weap_SniperRifles.A_Weapons.WeaponType_Vladof_Sniper PlayerViewOffset (X=40.000000,Y=3.000000,Z=-2.000000)
+set GD_Cork_Weap_Lasers.A_Weapons.WT_Dahl_Laser PlayerViewOffset (X=56.500000,Y=12.000000,Z=-6.000000)
+set GD_Cork_Weap_Lasers.A_Weapons.WT_Hyperion_Laser PlayerViewOffset (X=56.500000,Y=12.000000,Z=-6.000000)
+set GD_Cork_Weap_Lasers.A_Weapons.WT_Bandit_Laser PlayerViewOffset (X=56.500000,Y=12.000000,Z=-6.000000)
+set GD_Cork_Weap_Lasers.A_Weapons.WT_Maliwan_Laser PlayerViewOffset (X=56.500000,Y=12.000000,Z=-6.000000)
+set GD_Cork_Weap_Lasers.A_Weapons.WT_Tediore_Laser PlayerViewOffset (X=56.500000,Y=12.000000,Z=-6.000000)
+


### PR DESCRIPTION
This is a very small mod that just changes the positions of your weapons in Borderlands The Pre-Sequel. 
It's installed like any other Borderlands 2 or Borderlands the Pre-sequel patch/mods.

Here are two screenshots to see the difference: 

Before: https://imgur.com/gallery/J24tQOu
After: https://imgur.com/gallery/5bJGJ6x
Enjoy!