### PR TITLE
Add Commander Lilith DLC travel points

### DIFF
--- a/Borderlands 2 mods/FromDarkHell/Car Changes/CarAnywhere.txt
+++ b/Borderlands 2 mods/FromDarkHell/Car Changes/CarAnywhere.txt
@@ -1,4 +1,31 @@
 #<patch>
+    set GD_Anemone_LevelTravel.BackburnerToOldDust bAllowVehiclesToThisStation True
+
+    set GD_Anemone_LevelTravel.BackburnerToSanctIntro bAllowVehiclesToThisStation True
+
+    set GD_Anemone_LevelTravel.HeliosToSandwormCavern bAllowVehiclesToThisStation True
+
+    set GD_Anemone_LevelTravel.OldDustToBackburner bAllowVehiclesToThisStation True
+
+    set GD_Anemone_LevelTravel.OldDustToResearchCenter bAllowVehiclesToThisStation True
+
+    set GD_Anemone_LevelTravel.OldDustToSandwormCavern bAllowVehiclesToThisStation True
+
+    set GD_Anemone_LevelTravel.RaidBossToSandwormCavern bAllowVehiclesToThisStation True
+
+    set GD_Anemone_LevelTravel.ResearchCenterToOldDust bAllowVehiclesToThisStation True
+
+    set GD_Anemone_LevelTravel.ResearchCenterToSanctuary bAllowVehiclesToThisStation True
+
+    set GD_Anemone_LevelTravel.SanctIntroToBackburner bAllowVehiclesToThisStation True
+
+    set GD_Anemone_LevelTravel.SanctuaryToResearchCenter bAllowVehiclesToThisStation True
+
+    set GD_Anemone_LevelTravel.SandwormCavernToHelios bAllowVehiclesToThisStation True
+
+    set GD_Anemone_LevelTravel.SandwormCavernToOldDust bAllowVehiclesToThisStation True
+
+    set GD_Anemone_LevelTravel.SandwormCavernToRaidBoss bAllowVehiclesToThisStation True
 
     set GD_Iris_LevelTravelStations.BeatdowntoPyroPeats bAllowVehiclesToThisStation True
 


### PR DESCRIPTION
@FromDarkHell Sorry about that last PR, I missed you already had a TPS Car Anywhere mod. Anyway, this PR adds the travel points from the new DLC to your BL2 Car Anywhere list. Data comes from [Gibbed](https://github.com/gibbed/Gibbed.Borderlands2/blob/master/projects/Gibbed.Borderlands2.GameInfo/Resources/Travel%20Stations.json).