### PR TITLE
remove tps experiments file from modcabinet

### DIFF
--- a/Pre Sequel Mods/apple1417/cabinet.info
+++ b/Pre Sequel Mods/apple1417/cabinet.info
@@ -1,4 +1,3 @@
-Experimental.blcm: fast-travel
 FastTravelHelper.blcm: fast-travel
 GrenadeStatusChanceDisplayer.blcm: qol-ui
 HigherLevelScalingRemover.blcm: scaling


### PR DESCRIPTION
it's just one of the many files detected as "patch", and it'd not really something you should install