### PR TITLE
Polishing Details on my Mods - Sanity Check Disabler Recommendations Changed

### DIFF
--- a/Borderlands 2 mods/sage-72/PimpRGB.txt
+++ b/Borderlands 2 mods/sage-72/PimpRGB.txt
@@ -11,8 +11,8 @@
 			<category name="Description">
 				<comment>By sage-72</comment>
 				<comment>!!!!!!!!! VERY IMPORTANT !!!!!!!!!!</comment>
-				<comment>You Need to Disable Sanity Check through Hex Multitool or SDK Mod Sanity Saver if you don't want your Pimpernel to get deleted and have to re-farm them or copy-pasted in</comment>
-				<comment>You need to install SDK Mod "Command Extensions" for it to work</comment>
+				<comment>You need to install SDK Mod "Sanity Saver" if you don't want your Pimpernel to get deleted and have to re-farm them or copy-pasted in.</comment>
+				<comment>You need to install SDK Mod "Command Extensions" or your pellets won't fire. So, get both of the SDK Mods.</comment>
 				<comment>If you dont know what an SDK Mod is, install "Willow2 SDK" first https://bl-sdk.github.io/willow2-mod-db/</comment>
 				<comment>###################################</comment>
 				<comment>After Installing</comment>
@@ -29,7 +29,7 @@
 				<comment>Added E-Tech Barrel with Flaps</comment>
 				<comment>Changed Name to Prism-nel</comment>
 				<comment>Changed Red Text</comment>
-				<comment>##############</comment>
+				<comment>###################################</comment>
 				<comment>Special Thanks to:</comment>
 				<comment>Aaron0000 for giving me permission to use his Chroma code as a base/template for making the code for the Bullets as well as letting me use his code to change the barrel to be E-Tech with the flaps</comment>
 				<comment>EdamaneTv ZetaDaemon and PawnM0v3 for helping me understand how to code all of this in the first place.</comment>

--- a/Borderlands 2 mods/sage-72/README.md
+++ b/Borderlands 2 mods/sage-72/README.md
@@ -19,7 +19,7 @@ Changed Name to Prism-nel
 Changed Red Text
 
 
-PREREQUISITES: Command Extension SDK Mod and probably disable your Sanity Check too
+PREREQUISITES: Command Extension SDK Mod and Sanity Saver SDK Mod (to disable sanity check)
 
 If you dont know what an SDK Mod is, install "Willow2 SDK" first https://bl-sdk.github.io/willow2-mod-db/
 

--- a/Borderlands 2 mods/sage-72/cabinet.info
+++ b/Borderlands 2 mods/sage-72/cabinet.info
@@ -1,3 +1,3 @@
 PimpRGB.txt, gear-sniper	
-Different Element for every pellet|https://imgur.com/a/AkpWaM5
-Info|https://imgur.com/a/HCd5APj
+Different Element for every pellet|https://i.imgur.com/a/AkpWaM5.png
+Info|https://i.imgur.com/a/HCd5APj.png


### PR DESCRIPTION
My descriptions included recommending Hex Multitool to disable Sanity Check and i was told this is not a recommended way to do it anymore. So, I removed those and instead suggested to use SDK Mod Sanity Saver.

I also edited my cabinet.info since they were hyperlinking my images instead of displaying them. So, i added .png at the end of the links.